### PR TITLE
Fix carbon count in 13C NMR property

### DIFF
--- a/app/Compound.php
+++ b/app/Compound.php
@@ -229,7 +229,7 @@ class Compound extends Model
     {
         $regex = '/(\d+\.\d+)\s*,/';
 
-        preg_match_all($regex, $this->C_NMR_data, $matches);
+        preg_match_all($regex, $this->C_NMR_data . ',', $matches);
 
         return collect($matches[1])->count();
     }


### PR DESCRIPTION
Update the regular expression to account for the last signal in 13C NMR. As mentioned in issue #11.

Add a comma after the last digit, so the regEx is properly applied.

Closes #11