### PR TITLE
Fix degree celsius markup in melting point.

### DIFF
--- a/config/hashing.php
+++ b/config/hashing.php
@@ -44,9 +44,9 @@ return [
     */
 
     'argon' => [
-        'memory' => 1024,
+        'memory'  => 1024,
         'threads' => 2,
-        'time' => 2,
+        'time'    => 2,
     ],
 
 ];

--- a/config/logging.php
+++ b/config/logging.php
@@ -34,47 +34,47 @@ return [
 
     'channels' => [
         'stack' => [
-            'driver' => 'stack',
+            'driver'   => 'stack',
             'channels' => ['single'],
         ],
 
         'single' => [
             'driver' => 'single',
-            'path' => storage_path('logs/laravel.log'),
-            'level' => 'debug',
+            'path'   => storage_path('logs/laravel.log'),
+            'level'  => 'debug',
         ],
 
         'daily' => [
             'driver' => 'daily',
-            'path' => storage_path('logs/laravel.log'),
-            'level' => 'debug',
-            'days' => 7,
+            'path'   => storage_path('logs/laravel.log'),
+            'level'  => 'debug',
+            'days'   => 7,
         ],
 
         'slack' => [
-            'driver' => 'slack',
-            'url' => env('LOG_SLACK_WEBHOOK_URL'),
+            'driver'   => 'slack',
+            'url'      => env('LOG_SLACK_WEBHOOK_URL'),
             'username' => 'Laravel Log',
-            'emoji' => ':boom:',
-            'level' => 'critical',
+            'emoji'    => ':boom:',
+            'level'    => 'critical',
         ],
 
         'stderr' => [
-            'driver' => 'monolog',
+            'driver'  => 'monolog',
             'handler' => StreamHandler::class,
-            'with' => [
+            'with'    => [
                 'stream' => 'php://stderr',
             ],
         ],
 
         'syslog' => [
             'driver' => 'syslog',
-            'level' => 'debug',
+            'level'  => 'debug',
         ],
 
         'errorlog' => [
             'driver' => 'errorlog',
-            'level' => 'debug',
+            'level'  => 'debug',
         ],
     ],
 

--- a/resources/views/compounds/show.blade.php
+++ b/resources/views/compounds/show.blade.php
@@ -57,7 +57,7 @@
         @endif
 
          @if ($compound->melting_point && $compound->melting_point !== "@")
-            <strong>M.p.</strong>: {{ $compound->melting_point }} &deg; C.
+            <strong>M.p.</strong>: {{ $compound->melting_point }} &deg;C.
         @endif
         </div>
 
@@ -166,7 +166,7 @@
                         @elseif($compound->melting_point == "")
                             (not yet determined)
                         @else 
-                            {{ $compound->melting_point }} &deg; C.
+                            {{ $compound->melting_point }} &deg;C.
                         @endif
                     </td>
                 </tr>

--- a/resources/views/projects/export.blade.php
+++ b/resources/views/projects/export.blade.php
@@ -51,7 +51,7 @@
             @endif
 
              @if ($compound->melting_point && $compound->melting_point !== "@")
-                <strong>M.p.</strong>: {{ $compound->melting_point }} &deg; C.
+                <strong>M.p.</strong>: {{ $compound->melting_point }} &deg;C.
             @endif
             <br><br>
         @endforeach


### PR DESCRIPTION
Remove the space between the degree sign and Celcius when showing a Melting Point.

Closes #19 